### PR TITLE
Leaving SerialNumber as a string

### DIFF
--- a/mettler_toledo_device/mettler_toledo_device.py
+++ b/mettler_toledo_device/mettler_toledo_device.py
@@ -192,7 +192,7 @@ class MettlerToledoDevice(object):
         response = self._send_request_get_response('I4')
         if 'I' in response[1]:
             raise MettlerToledoError('Command understood, not executable at present.')
-        return int(response[2])
+        return response[2]
 
     def get_software_id(self):
         '''


### PR DESCRIPTION
The serial_number is alphanumeric on some scales - so casting as an int makes it unable to find the scales